### PR TITLE
Fixed onGetStatus for Safari

### DIFF
--- a/background/event.js
+++ b/background/event.js
@@ -159,11 +159,11 @@ mooltipassEvent.onGetStatus = function (callback, tab) {
         status: mooltipass.device.getStatus(),
         error: undefined,
         blacklisted: false,
-        hideCustomCredentials: twoPageAuthServices.some(function (domain) { return (new URL(tab.url).hostname).match(domain) })
-
+        hideCustomCredentials: false
     };
 
     if (tab && tab.url) {
+        toReturn.hideCustomCredentials = twoPageAuthServices.some(function (domain) { return (new URL(tab.url).hostname).match(domain) });
         var tabStatus = mooltipass.backend.extractDomainAndSubdomain(tab.url);
         toReturn.blacklisted = tabStatus.blacklisted;
     }

--- a/popups/js/popup_status.js
+++ b/popups/js/popup_status.js
@@ -1,24 +1,24 @@
 
 // Detect if we're dealing with Firefox, Safari, or Chrome
 var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-var isSafari = typeof(safari) == 'object'?true:false;
+var isSafari = typeof (safari) == 'object' ? true : false;
 
-var _settings = typeof(localStorage.settings)=='undefined' ? {} : JSON.parse(localStorage.settings);
+var _settings = typeof (localStorage.settings) == 'undefined' ? {} : JSON.parse(localStorage.settings);
 
-if ( isSafari ) {
-    if ( safari.extension.globalPage ) messaging = safari.extension.globalPage.contentWindow.messaging;
-    else messaging = function() {}
+if (isSafari) {
+    if (safari.extension.globalPage) messaging = safari.extension.globalPage.contentWindow.messaging;
+    else messaging = function () { }
 } else {
     // Unify messaging method - And eliminate callbacks (a message is replied with another message instead)
-    function messaging( message, callback ) {
-        chrome.runtime.sendMessage( message, callback );
-    };    
+    function messaging(message, callback) {
+        chrome.runtime.sendMessage(message, callback);
+    };
 }
 
 function initSettings() {
-    if ( isSafari ) {
+    if (isSafari) {
         // Safari new method requires this to open a link
-        mpJQ('#btn-link').click(function() {
+        mpJQ('#btn-link').click(function () {
             safari.application.activeBrowserWindow.openTab().url = "http://themooltipass.com/";
         });
     }
@@ -26,14 +26,14 @@ function initSettings() {
     // Display strings in proper locale
     initLocale();
 
-    mpJQ(".pure-menu-list .pure-menu-item").click(function() {
+    mpJQ(".pure-menu-list .pure-menu-item").click(function () {
         if (isSafari) {
             safari.self.hide();
         }
     });
 
-    mpJQ("#btn-settings").click(function( e ) {
-        if ( isSafari ) {
+    mpJQ("#btn-settings").click(function (e) {
+        if (isSafari) {
             e.preventDefault();
             safari.application.activeBrowserWindow.openTab().url = safari.extension.baseURI + "options/options.html";
         } else {
@@ -43,18 +43,18 @@ function initSettings() {
         }
     });
 
-    mpJQ("#btn-open-app").click(function(e) {
+    mpJQ("#btn-open-app").click(function (e) {
         e.preventDefault();
-        messaging( { action: "show_app" }, function() {} );
-        if ( !isSafari ) close();
+        messaging({ action: "show_app" }, function () { });
+        if (!isSafari) close();
     });
 
-    mpJQ("#btn-report-error").click(function(e) {
-        if ( isSafari ) {
+    mpJQ("#btn-report-error").click(function (e) {
+        if (isSafari) {
             e.preventDefault();
             safari.application.activeBrowserWindow.openTab().url = "https://docs.google.com/forms/d/1lFKaTR3LQxySyGsZwtHudVE6aGErGU2DHfn-YpuW8aE/viewform?entry.449375470=" + safari.application.activeBrowserWindow.activeTab.url;
         } else {
-            mooltipass.website.reportError( function(target_url){
+            mooltipass.website.reportError(function (target_url) {
                 chrome.tabs.create({
                     url: target_url
                 })
@@ -62,11 +62,11 @@ function initSettings() {
         }
     });
 
-    mpJQ("#btn-select-credential-fields").click(function( e ) {
+    mpJQ("#btn-select-credential-fields").click(function (e) {
         e.preventDefault()
         if ($(this).hasClass('disabled')) return
-      
-        if ( isSafari ) {
+
+        if (isSafari) {
             var global = safari.extension.globalPage.contentWindow;
             global.mooltipass.website.chooseCredentialFields();
         } else {
@@ -76,45 +76,53 @@ function initSettings() {
         }
     });
 
-    mpJQ("#btn-add-site-to-blacklist").click(function( e ) {
-        if ( isSafari ) {
+    mpJQ("#btn-add-site-to-blacklist").click(function (e) {
+        if (isSafari) {
             e.preventDefault();
             var message = { action: "blacklist_url", args: [safari.application.activeBrowserWindow.activeTab.url] };
-            messaging( message, function() {} );
+            messaging(message, function () { });
         } else {
-            chrome.tabs.query({currentWindow: true, active: true}, function(tabs) {
+            chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
                 chrome.runtime.sendMessage({
                     action: 'blacklist_url',
                     args: [tabs[0].url]
-                }, function() {});
+                }, function () { });
                 close();
             });
         }
     });
 
-    mpJQ("#btn-remove-site-from-blacklist").click(function(e) {
-        if ( isSafari ) {
+    mpJQ("#btn-remove-site-from-blacklist").click(function (e) {
+        if (isSafari) {
             e.preventDefault();
             var message = { action: "unblacklist_url", args: [safari.application.activeBrowserWindow.activeTab.url] };
-            messaging( message, function() {} );
+            messaging(message, function () { });
         } else {
-            chrome.tabs.query({currentWindow: true, active: true}, function(tabs) {
+            chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
                 chrome.runtime.sendMessage({
                     action: 'unblacklist_url',
                     args: [tabs[0].url]
-                }, function() {});
+                }, function () { });
                 close();
             });
         }
     });
 }
 
-function getStatusCallback( object ) {
-     mpJQ('#status-bar .status > span').hide();
-     console.log(object)
+function getSafariTabId(tab) {
+    for (var i = 0; i < safari.application.activeBrowserWindow.tabs.length; i++) {
+        if (safari.application.activeBrowserWindow.tabs[i] == tab) {
+            return i
+        }
+    }
+}
 
-     mpJQ('#btn-select-credential-fields').toggleClass('disabled', object.hideCustomCredentials)
-     
+function getStatusCallback(object) {
+    mpJQ('#status-bar .status > span').hide();
+    console.log(object)
+
+    mpJQ('#btn-select-credential-fields').toggleClass('disabled', object.hideCustomCredentials)
+
     // Connection to app established, device connected and unlocked
     if (object.status.deviceUnlocked && object.status.connectedToDevice && object.status.connectedToApp) {
         mpJQ('#device-unlocked').show();
@@ -128,7 +136,7 @@ function getStatusCallback( object ) {
         mpJQ('#device-disconnected').show();
     }
     // No app found
-    else if(!object.status.connectedToApp) {
+    else if (!object.status.connectedToApp) {
         mpJQ('#app-missing').show();
     }
     // Unknown error
@@ -136,7 +144,7 @@ function getStatusCallback( object ) {
         mpJQ('#unknown-error').show();
     }
 
-    if ( object.blacklisted ) {
+    if (object.blacklisted) {
         mpJQ('#btn-remove-site-from-blacklist').show();
         mpJQ('#btn-add-site-to-blacklist').hide();
     } else {
@@ -146,21 +154,21 @@ function getStatusCallback( object ) {
 }
 
 function updateStatusInfo() {
-    if( isSafari ) {
-        if ( safari.extension.globalPage && safari.extension.globalPage.contentWindow.mooltipassEvent) {
+    if (isSafari) {
+        if (safari.extension.globalPage && safari.extension.globalPage.contentWindow.mooltipassEvent) {
             safari.extension.globalPage.contentWindow.mooltipassEvent.onGetStatus(getStatusCallback, {
                 id: getSafariTabId(safari.application.activeBrowserWindow.activeTab),
                 url: safari.application.activeBrowserWindow.activeTab.url
             });
         }
     } else {
-        chrome.tabs.query({currentWindow: true, active: true}, function(tabs) {
-            messaging( { action: "get_status", overwrite_tab: tabs[0] }, getStatusCallback);
-        }); 
+        chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
+            messaging({ action: "get_status", overwrite_tab: tabs[0] }, getStatusCallback);
+        });
 
-        if ( typeof chrome.notifications.getPermissionLevel == 'function' ) {
+        if (typeof chrome.notifications.getPermissionLevel == 'function') {
             // Check if notifications are enabled
-            chrome.notifications.getPermissionLevel(function(response) {
+            chrome.notifications.getPermissionLevel(function (response) {
                 if (response == 'denied') {
                     mpJQ("#notifications-disabled").show();
                 }
@@ -216,10 +224,10 @@ function initLocale() {
     $("#unknown-error").text(chrome.i18n.getMessage("PopupStatusHtml_StatusBar_Unknown"));
 }
 
-mpJQ(function() {
+mpJQ(function () {
     initSettings();
     mpJQ('#status-bar .status > span').hide();
     mpJQ('#initial-state').show();
-        
+
     _updateStatusInfo();
 });


### PR DESCRIPTION
- Safari's start page tab has NULL properties causing the background/event.js->onGetStatus() function to trigger an unhandeld exception.
- Converted all tabs to spaces for consistency within popups/popup_status.js