### PR TITLE
Removed deprecated "options_page" from manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,11 @@
     "default_popup": "popups/popup_status.html"
   },
 
-  "options_page": "options/options.html",
+  "options_ui": {
+    "page": "options/options.html",
+    "open_in_tab": true
+  },
+
   "background": {
     "scripts": [
       "shared_scripts/psl.min.js",


### PR DESCRIPTION
- Replaced the deprecated "options_page" attribute with the new "options_ui" for FF compatibility.