### PR TITLE
Issue#13 Feature  when clicking "open mooltipass app".

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -62,6 +62,7 @@
   "PopupStatusHtml_Menu_Settings": { "message": "Settings" },
   "PopupStatusHtml_Menu_Website": { "message": "Mooltipass website" },
   "PopupStatusHtml_Menu_OpenApp": { "message": "Open Mooltipass App" },
+  "PopupStatusHtml_Menu_NoApp": { "message": "(no app installed)" },
   "PopupStatusHtml_Menu_ReportIssue": { "message": "Report incompatibilities with this website" },
   "PopupStatusHtml_StatusBar_CheckStatus": { "message": "checking status " },
   "PopupStatusHtml_StatusBar_DeviceUnlocked": { "message": "Device Unlocked" },

--- a/popups/js/popup_status.js
+++ b/popups/js/popup_status.js
@@ -138,6 +138,10 @@ function getStatusCallback(object) {
     // No app found
     else if (!object.status.connectedToApp) {
         mpJQ('#app-missing').show();
+        mpJQ("#btn-open-app").text(chrome.i18n.getMessage("PopupStatusHtml_Menu_OpenApp")+chrome.i18n.getMessage("PopupStatusHtml_Menu_NoApp"));
+        mpJQ("#btn-open-app").css("color","gray");
+        mpJQ("#btn-open-app").css("cursor","default");
+        mpJQ("#btn-open-app").off();
     }
     // Unknown error
     else {


### PR DESCRIPTION
-“(no app installed)” message added if app no connection with app
-Open Mooltipass app link disabled if no app connected
- new “PopupStatusHtml_Menu_NoApp” message for localisation - in
English only right now