### PR TITLE
fixes #127

### DIFF
--- a/background/page.js
+++ b/background/page.js
@@ -90,7 +90,8 @@ page.cacheLogin = function( callback, tab, arguments ) {
 	var tab_id = tab.id;
 
 	setTimeout(function(){
-		page.tabs[ tab_id ].loginList = { };
+		if (page.tabs[ tab_id ])
+			page.tabs[ tab_id ].loginList = { };
 	},30*1000);//clear cache item after 30 seconds
 
 }


### PR DESCRIPTION
Check that tab still exists before removing cached credentials.

see #127 